### PR TITLE
Update deprecated "next/prefetch"

### DIFF
--- a/layouts/main.js
+++ b/layouts/main.js
@@ -1,10 +1,10 @@
 import Meta from '../components/meta'
-import Link from 'next/prefetch'
+import Link from 'next/link'
 
 export default ({ children }) => (
   <div className="main">
     <div className="logo">
-      <Link href="/"><a>rauchg.com</a></Link>
+      <Link prefetch href="/"><a>rauchg.com</a></Link>
       {' '}
       (<a href={`https://github.com/rauchg/blog`} target="_blank">src</a>)
     </div>

--- a/pages/2017/2016-in-review.js
+++ b/pages/2017/2016-in-review.js
@@ -10,7 +10,7 @@ import UL, { LI } from '../../components/post/bullets-list'
 import { Ref, FootNotes, Note } from '../../components/post/footnotes'
 import Figure, { Image, Video } from '../../components/post/figure'
 import Quote from '../../components/post/quote'
-import Link from 'next/prefetch'
+import Link from 'next/link'
 import YouTube from '../../components/post/youtube'
 import Meta from '../../components/post/meta'
 import withViews from '../../lib/with-views'
@@ -187,7 +187,7 @@ export default withViews(({ views }) => (
 
     <P>And then just type in <Code>next</Code> and head to <Code>http://localhost/</Code>.</P>
 
-    <P>A few years ago I wrote about <Link href="/2014/7-principles-of-rich-web-applications"><a>7 principles</a></Link> that made for great UX
+    <P>A few years ago I wrote about <Link prefetch href="/2014/7-principles-of-rich-web-applications"><a>7 principles</a></Link> that made for great UX
     in the web. This tool enables those.</P>
 
     <P>Each <em>"page"</em> is a webpack entry-point. Each section
@@ -437,7 +437,7 @@ export default withViews(({ views }) => (
     <H3 id="essays">Essays</H3>
 
     <P>The only essay I wrote this year is
-    called <Link href="/2016/addressable-errors"><a>Addressable Errors</a></Link>.</P>
+    called <Link prefetch href="/2016/addressable-errors"><a>Addressable Errors</a></Link>.</P>
 
     <P>Inspired by React's excellent warnings, I decided that every time
     I write an error out to a terminal or console, I'll attach a URL to it.</P>

--- a/pages/essays.js
+++ b/pages/essays.js
@@ -1,5 +1,5 @@
 import Page from '../layouts/main'
-import Link from 'next/prefetch'
+import Link from 'next/link'
 import { posts } from '../posts'
 import Head from 'next/head'
 
@@ -26,7 +26,7 @@ export default () => (
 const Post = ({ id, date, title }) => (
   <div className="post">
     <span className="date">{ date }</span>
-    <Link href={`/${new Date(date).getFullYear()}/${id}`}><a>{ title }</a></Link>
+    <Link prefetch href={`/${new Date(date).getFullYear()}/${id}`}><a>{ title }</a></Link>
 
     <style jsx>{`
       .post {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import Page from '../layouts/main'
-import Link from 'next/prefetch'
+import Link from 'next/link'
 import Head from 'next/head'
 
 export default () => (
@@ -13,7 +13,7 @@ export default () => (
         <h1>Guillermo Rauch</h1>
         <nav>
           <a target="_blank" href="https://twitter.com/rauchg">Twitter</a>
-          <Link href="/essays"><a>Essays</a></Link>
+          <Link prefetch href="/essays"><a>Essays</a></Link>
           <a href="/gpg.asc" download>GPG</a>
           <a href="mailto:rauchg@gmail.com">Email</a>
         </nav>


### PR DESCRIPTION
* Removed deprecated next/prefetch for next/link
* Added prefetch prop to all `<Link>` components 

I was trying to figure out how the blog-views prevents abuse by logging IPs works and stumble into this. 