### PR TITLE
Add support for loading posts from Notion

### DIFF
--- a/components/issg-indicator.js
+++ b/components/issg-indicator.js
@@ -1,0 +1,51 @@
+import useSWR from 'swr'
+import Spinner from './spinner'
+import { useRouter } from 'next/router'
+import { useState, useEffect } from 'react'
+import useMounted from '../lib/use-mounted'
+
+export default function Indicator(props) {
+  const mounted = useMounted()
+  const { asPath } = useRouter()
+  const active = mounted && localStorage.issgIndicator
+  const [gotSuccess, setGotSuccess] = useState(false)
+
+  const { data, error } = useSWR(
+    () => (gotSuccess || !active ? null : 'revalidate-status'),
+    {
+      fetcher: async () => {
+        const res = await fetch(asPath, {
+          method: 'HEAD',
+          headers: {
+            pragma: 'no-cache'
+          }
+        })
+        const status = (res.headers.get('x-now-cache') || '').toLowerCase()
+        return status === 'hit' ? 'done' : 'revalidating'
+      },
+      refreshInterval: 500,
+      revalidateOnFocus: false,
+    }
+  )
+
+  useEffect(() => {
+    if (data === 'done') {
+      setGotSuccess(true)
+    }
+  }, [data])
+
+  return !active ? null : (
+    <>
+      <div className='issg-indicator'>
+        {gotSuccess ? '✔️' : <Spinner size={24} color="#333333" />}
+      </div>
+      <style jsx>{`
+        .issg-indicator {
+          position: fixed;
+          right: 35px;
+          bottom: 35px;
+        }
+      `}</style>
+    </>
+  )
+}

--- a/components/shared.js
+++ b/components/shared.js
@@ -1,0 +1,36 @@
+import Code from "../components/post/code";
+import Quote from "../components/post/quote";
+import P from "../components/post/paragraph";
+import Tweet from "../components/post/tweet";
+import Snippet from "../components/post/snippet";
+import YouTube from "../components/post/youtube";
+import { H2, H3 } from "../components/post/heading";
+import UL, { LI } from "../components/post/bullets-list";
+import Figure, { Image } from "../components/post/figure";
+import { Ref, FootNotes, Note } from "../components/post/footnotes";
+
+const components = {
+  p: P,
+  ul: UL,
+  li: LI,
+  h2: H2,
+  h3: H3,
+  blockquote: Quote,
+
+  Quote,
+  P,
+  Tweet,
+  Code,
+  Snippet,
+  H2,
+  Figure,
+  Image,
+  Ref,
+  FootNotes,
+  Note,
+  UL,
+  LI,
+  YouTube
+};
+
+export default components;

--- a/components/spinner.js
+++ b/components/spinner.js
@@ -1,0 +1,54 @@
+import React from 'react'
+
+export default function Spinner({ color, className, size }) {
+  const bars = []
+
+  for (let i = 0; i < 12; i++) {
+    const barStyle = {}
+    barStyle.animationDelay = (i - 12) / 10 + 's'
+    barStyle.transform = 'rotate(' + i * 30 + 'deg) translate(146%)'
+    bars.push(<div style={barStyle} className="react-spinner_bar" key={i} />)
+  }
+
+  return (
+    <div className={`wrapper${className ? ' ' + className : ''}`}>
+      <div className="react-spinner">{bars}</div>
+      <style jsx>
+        {`
+          .wrapper {
+            height: ${size}px;
+            width: ${size}px;
+          }
+
+          .react-spinner {
+            height: ${size}px;
+            left: 50%;
+            position: relative;
+            top: 50%;
+            width: ${size}px;
+          }
+
+          .react-spinner :global(.react-spinner_bar) {
+            animation: react-spinner_spin 1.2s linear infinite;
+            background-color: ${color};
+            border-radius: 5px;
+            height: 8%;
+            left: -10%;
+            position: absolute;
+            top: -3.9%;
+            width: 24%;
+          }
+
+          @keyframes react-spinner_spin {
+            0% {
+              opacity: 1;
+            }
+            100% {
+              opacity: 0.15;
+            }
+          }
+        `}
+      </style>
+    </div>
+  )
+}

--- a/lib/atom.js
+++ b/lib/atom.js
@@ -1,7 +1,10 @@
-const {posts} = require('../posts')
-const max = 10 // max returned posts
+import getCombinedPosts from "./get-combined-posts";
+const max = 10; // max returned posts
 
-module.exports = () => `<?xml version="1.0" encoding="utf-8"?>
+export default async function atom() {
+  const posts = await getCombinedPosts();
+
+  return `<?xml version="1.0" encoding="utf-8"?>
   <feed xmlns="http://www.w3.org/2005/Atom">
     <title>Guillermo Rauch</title>
     <subtitle>Essays</subtitle>
@@ -18,9 +21,12 @@ module.exports = () => `<?xml version="1.0" encoding="utf-8"?>
         <entry>
           <id>${post.id}</id>
           <title>${post.title}</title>
-          <link href="https://rauchg.com/${post.date.match(/\d{4}/)[0]}/${post.id}"/>
+          <link href="https://rauchg.com/${post.date.match(/\d{4}/)[0]}/${
+        post.id
+      }"/>
           <updated>${post.date}</updated>
-        </entry>`
-      }, '')}
+        </entry>`;
+    }, "")}
   </feed>
-`
+`;
+}

--- a/lib/blog-helpers.js
+++ b/lib/blog-helpers.js
@@ -1,0 +1,26 @@
+export const getBlogLink = slug => {
+  return `${slug.startsWith("/") ? "" : "/"}${slug}`;
+};
+
+export const getDateStr = date => {
+  return new Date(date).toLocaleString("en-US", {
+    month: "long",
+    day: "2-digit",
+    year: "numeric"
+  });
+};
+
+const collectText = (el, acc = []) => {
+  if (el) {
+    if (typeof el === "string") acc.push(el);
+    if (Array.isArray(el)) el.map(item => collectText(item, acc));
+    if (typeof el === "object") collectText(el.props && el.props.children, acc);
+  }
+  return acc.join("").trim();
+};
+
+export const getHeadingId = children =>
+  collectText(children)
+    .toLowerCase()
+    .replace(/\s/g, "-")
+    .replace(/[?!:]/g, "");

--- a/lib/blog-helpers.js
+++ b/lib/blog-helpers.js
@@ -10,6 +10,21 @@ export const getDateStr = date => {
   });
 };
 
+export const normalizeSlug = slug => {
+  if (typeof slug !== 'string') return slug
+
+  let startingSlash = slug.startsWith('/')
+  let endingSlash = slug.endsWith('/')
+
+  if (startingSlash) {
+    slug = slug.substr(1)
+  }
+  if (endingSlash) {
+    slug = slug.substr(0, slug.length - 1)
+  }
+  return (startingSlash || endingSlash) ? normalizeSlug(slug) : slug
+}
+
 const collectText = (el, acc = []) => {
   if (el) {
     if (typeof el === "string") acc.push(el);

--- a/lib/fs-helpers.ts
+++ b/lib/fs-helpers.ts
@@ -1,0 +1,5 @@
+import fs from "fs";
+import { promisify } from "util";
+
+export const readFile = promisify(fs.readFile);
+export const writeFile = promisify(fs.writeFile);

--- a/lib/get-combined-posts.js
+++ b/lib/get-combined-posts.js
@@ -1,0 +1,34 @@
+import { posts } from "../posts";
+import getBlogIndex from "./notion/getBlogIndex";
+import { getDateStr, getBlogLink } from "./blog-helpers";
+
+export default async function getCombinedPosts() {
+  const postsTable = await getBlogIndex(false);
+
+  const notionPosts = Object.keys(postsTable)
+    .map(slug => {
+      const post = postsTable[slug];
+      // remove draft posts in production
+      if (process.env.NODE_ENV === "production" && post.Published !== "Yes") {
+        return null;
+      }
+      return post;
+    })
+    .filter(Boolean);
+
+  const combinedPosts = [
+    ...notionPosts.map(post => ({
+      date: getDateStr(post.Date),
+      title: post.Page,
+      id: post.Slug,
+      notion: true,
+      url: getBlogLink(post.Slug)
+    })),
+    ...posts.map(post => ({
+      ...post,
+      url: `${new Date(post.date).getFullYear()}/${post.id}`
+    }))
+  ];
+
+  return combinedPosts;
+}

--- a/lib/notion/createTable.js
+++ b/lib/notion/createTable.js
@@ -1,0 +1,374 @@
+// commonjs so it can be run without transpiling
+const uuid = require("uuid/v4");
+const fetch = require("node-fetch");
+const {
+  BLOG_INDEX_ID: pageId,
+  NOTION_TOKEN,
+  API_ENDPOINT
+} = require("./server-constants");
+
+async function main() {
+  const userId = await getUserId();
+  const transactionId = () => uuid();
+  const collectionId = uuid();
+  const collectionViewId = uuid();
+  const viewId = uuid();
+  const now = Date.now();
+  const pageId1 = uuid();
+  const pageId2 = uuid();
+  const pageId3 = uuid();
+  let existingBlockId = await getExistingexistingBlockId();
+
+  const requestBody = {
+    requestId: uuid(),
+    transactions: [
+      {
+        id: transactionId(),
+        operations: [
+          {
+            id: collectionId,
+            table: "block",
+            path: [],
+            command: "update",
+            args: {
+              id: collectionId,
+              type: "collection_view",
+              collection_id: collectionViewId,
+              view_ids: [viewId],
+              properties: {},
+              created_time: now,
+              last_edited_time: now
+            }
+          },
+          {
+            id: pageId1,
+            table: "block",
+            path: [],
+            command: "update",
+            args: {
+              id: pageId1,
+              type: "page",
+              parent_id: collectionViewId,
+              parent_table: "collection",
+              alive: true,
+              properties: {},
+              created_time: now,
+              last_edited_time: now
+            }
+          },
+          {
+            id: pageId2,
+            table: "block",
+            path: [],
+            command: "update",
+            args: {
+              id: pageId2,
+              type: "page",
+              parent_id: collectionViewId,
+              parent_table: "collection",
+              alive: true,
+              properties: {},
+              created_time: now,
+              last_edited_time: now
+            }
+          },
+          {
+            id: pageId3,
+            table: "block",
+            path: [],
+            command: "update",
+            args: {
+              id: pageId3,
+              type: "page",
+              parent_id: collectionViewId,
+              parent_table: "collection",
+              alive: true,
+              properties: {},
+              created_time: now,
+              last_edited_time: now
+            }
+          },
+          {
+            id: viewId,
+            table: "collection_view",
+            path: [],
+            command: "update",
+            args: {
+              id: viewId,
+              version: 0,
+              type: "table",
+              name: "Default View",
+              format: {
+                table_properties: [
+                  { property: "title", visible: true, width: 276 },
+                  { property: 'S6_"', visible: true },
+                  { property: "la`A", visible: true },
+                  { property: "a`af", visible: true },
+                  { property: "ijjk", visible: true }
+                ],
+                table_wrap: true
+              },
+              query2: {
+                aggregations: [{ property: "title", aggregator: "count" }]
+              },
+              page_sort: [pageId1, pageId2, pageId3],
+              parent_id: collectionId,
+              parent_table: "block",
+              alive: true
+            }
+          },
+          {
+            id: collectionViewId,
+            table: "collection",
+            path: [],
+            command: "update",
+            args: {
+              id: collectionViewId,
+              schema: {
+                title: { name: "Page", type: "title" },
+                'S6_"': { name: "Slug", type: "text" },
+                "la`A": { name: "Published", type: "checkbox" },
+                "a`af": { name: "Date", type: "date" },
+                ijjk: { name: "Authors", type: "person" }
+              },
+              format: {
+                collection_page_properties: [
+                  { property: 'S6_"', visible: true },
+                  { property: "la`A", visible: true },
+                  { property: "a`af", visible: true },
+                  { property: "ijjk", visible: true }
+                ]
+              },
+              parent_id: collectionId,
+              parent_table: "block",
+              alive: true
+            }
+          },
+          {
+            id: collectionId,
+            table: "block",
+            path: [],
+            command: "update",
+            args: { parent_id: pageId, parent_table: "block", alive: true }
+          },
+          {
+            table: "block",
+            id: pageId,
+            path: ["content"],
+            command: "listAfter",
+            args: {
+              ...(existingBlockId
+                ? {
+                    after: existingBlockId
+                  }
+                : {}),
+              id: collectionId
+            }
+          },
+          {
+            table: "block",
+            id: collectionId,
+            path: ["created_by_id"],
+            command: "set",
+            args: userId
+          },
+          {
+            table: "block",
+            id: collectionId,
+            path: ["created_by_table"],
+            command: "set",
+            args: "notion_user"
+          },
+          {
+            table: "block",
+            id: collectionId,
+            path: ["last_edited_time"],
+            command: "set",
+            args: now
+          },
+          {
+            table: "block",
+            id: collectionId,
+            path: ["last_edited_by_id"],
+            command: "set",
+            args: userId
+          },
+          {
+            table: "block",
+            id: collectionId,
+            path: ["last_edited_by_table"],
+            command: "set",
+            args: "notion_user"
+          },
+          {
+            table: "block",
+            id: pageId1,
+            path: ["created_by_id"],
+            command: "set",
+            args: userId
+          },
+          {
+            table: "block",
+            id: pageId1,
+            path: ["created_by_table"],
+            command: "set",
+            args: "notion_user"
+          },
+          {
+            table: "block",
+            id: pageId1,
+            path: ["last_edited_time"],
+            command: "set",
+            args: now
+          },
+          {
+            table: "block",
+            id: pageId1,
+            path: ["last_edited_by_id"],
+            command: "set",
+            args: userId
+          },
+          {
+            table: "block",
+            id: pageId1,
+            path: ["last_edited_by_table"],
+            command: "set",
+            args: "notion_user"
+          },
+          {
+            table: "block",
+            id: pageId2,
+            path: ["created_by_id"],
+            command: "set",
+            args: userId
+          },
+          {
+            table: "block",
+            id: pageId2,
+            path: ["created_by_table"],
+            command: "set",
+            args: "notion_user"
+          },
+          {
+            table: "block",
+            id: pageId2,
+            path: ["last_edited_time"],
+            command: "set",
+            args: now
+          },
+          {
+            table: "block",
+            id: pageId2,
+            path: ["last_edited_by_id"],
+            command: "set",
+            args: userId
+          },
+          {
+            table: "block",
+            id: pageId2,
+            path: ["last_edited_by_table"],
+            command: "set",
+            args: "notion_user"
+          },
+          {
+            table: "block",
+            id: pageId3,
+            path: ["created_by_id"],
+            command: "set",
+            args: userId
+          },
+          {
+            table: "block",
+            id: pageId3,
+            path: ["created_by_table"],
+            command: "set",
+            args: "notion_user"
+          },
+          {
+            table: "block",
+            id: pageId3,
+            path: ["last_edited_time"],
+            command: "set",
+            args: now
+          },
+          {
+            table: "block",
+            id: pageId3,
+            path: ["last_edited_by_id"],
+            command: "set",
+            args: userId
+          },
+          {
+            table: "block",
+            id: pageId3,
+            path: ["last_edited_by_table"],
+            command: "set",
+            args: "notion_user"
+          }
+        ]
+      }
+    ]
+  };
+
+  const res = await fetch(`${API_ENDPOINT}/submitTransaction`, {
+    method: "POST",
+    headers: {
+      cookie: `token_v2=${NOTION_TOKEN}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(requestBody)
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to add table, request status ${res.status}`);
+  }
+}
+
+async function getExistingexistingBlockId() {
+  const res = await fetch(`${API_ENDPOINT}/loadPageChunk`, {
+    method: "POST",
+    headers: {
+      cookie: `token_v2=${NOTION_TOKEN}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      pageId,
+      limit: 25,
+      cursor: { stack: [] },
+      chunkNumber: 0,
+      verticalColumns: false
+    })
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `failed to get existing block id, request status: ${res.status}`
+    );
+  }
+  const data = await res.json();
+  const id = Object.keys(data ? data.recordMap.block : {}).find(
+    id => id !== pageId
+  );
+  return id || uuid();
+}
+
+async function getUserId() {
+  const res = await fetch(`${API_ENDPOINT}/loadUserContent`, {
+    method: "POST",
+    headers: {
+      cookie: `token_v2=${NOTION_TOKEN}`,
+      "content-type": "application/json"
+    },
+    body: "{}"
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `failed to get Notion user id, request status: ${res.status}`
+    );
+  }
+  const data = await res.json();
+  return Object.keys(data.recordMap.notion_user)[0];
+}
+
+module.exports = main;

--- a/lib/notion/getBlogIndex.ts
+++ b/lib/notion/getBlogIndex.ts
@@ -1,0 +1,68 @@
+import { Sema } from "async-sema";
+import rpc, { values } from "./rpc";
+import getTableData from "./getTableData";
+import { getPostPreview } from "./getPostPreview";
+import { readFile, writeFile } from "../fs-helpers";
+import { BLOG_INDEX_ID, BLOG_INDEX_CACHE } from "./server-constants";
+
+export default async function getBlogIndex(previews = true) {
+  let postsTable: any = null;
+  const isProd = process.env.NODE_ENV === "production";
+  const cacheFile = `${BLOG_INDEX_CACHE}${previews ? "_previews" : ""}`;
+
+  if (isProd) {
+    try {
+      postsTable = JSON.parse(await readFile(cacheFile, "utf8"));
+    } catch (_) {
+      /* not fatal */
+    }
+  }
+
+  if (!postsTable) {
+    const data = await rpc("loadPageChunk", {
+      pageId: BLOG_INDEX_ID,
+      limit: 999, // TODO: figure out Notion's way of handling pagination
+      cursor: { stack: [] },
+      chunkNumber: 0,
+      verticalColumns: false
+    });
+
+    // Parse table with posts
+    const tableBlock = values(data.recordMap.block).find(
+      (block: any) => block.value.type === "collection_view"
+    );
+
+    postsTable = await getTableData(tableBlock, true);
+    // only get 10 most recent post's previews
+    const postsKeys = Object.keys(postsTable).splice(0, 10);
+
+    const sema = new Sema(3, { capacity: postsKeys.length });
+
+    if (previews) {
+      await Promise.all(
+        postsKeys
+          .sort((a, b) => {
+            const postA = postsTable[a];
+            const postB = postsTable[b];
+            const timeA = postA.Date;
+            const timeB = postB.Date;
+            return Math.sign(timeB - timeA);
+          })
+          .map(async postKey => {
+            await sema.acquire();
+            const post = postsTable[postKey];
+            post.preview = post.id
+              ? await getPostPreview(postsTable[postKey].id)
+              : [];
+            sema.release();
+          })
+      );
+    }
+
+    if (isProd) {
+      writeFile(cacheFile, JSON.stringify(postsTable), "utf8").catch(() => {});
+    }
+  }
+
+  return postsTable;
+}

--- a/lib/notion/getBlogIndex.ts
+++ b/lib/notion/getBlogIndex.ts
@@ -19,20 +19,29 @@ export default async function getBlogIndex(previews = true) {
   }
 
   if (!postsTable) {
-    const data = await rpc("loadPageChunk", {
-      pageId: BLOG_INDEX_ID,
-      limit: 999, // TODO: figure out Notion's way of handling pagination
-      cursor: { stack: [] },
-      chunkNumber: 0,
-      verticalColumns: false
-    });
+    try {
+      const data = await rpc("loadPageChunk", {
+        pageId: BLOG_INDEX_ID,
+        limit: 999, // TODO: figure out Notion's way of handling pagination
+        cursor: { stack: [] },
+        chunkNumber: 0,
+        verticalColumns: false
+      });
 
-    // Parse table with posts
-    const tableBlock = values(data.recordMap.block).find(
-      (block: any) => block.value.type === "collection_view"
-    );
+      // Parse table with posts
+      const tableBlock = values(data.recordMap.block).find(
+        (block: any) => block.value.type === "collection_view"
+      );
 
-    postsTable = await getTableData(tableBlock, true);
+      postsTable = await getTableData(tableBlock, true);
+    } catch (err) {
+      console.error(
+        `\nFailed to load Notion posts, did you configure your Notion table as an inline table according to https://github.com/ijjk/notion-blog#creating-your-pages-table\n`
+      );
+      console.error(err);
+      postsTable = {};
+    }
+
     // only get 10 most recent post's previews
     const postsKeys = Object.keys(postsTable).splice(0, 10);
 

--- a/lib/notion/getBlogIndex.ts
+++ b/lib/notion/getBlogIndex.ts
@@ -1,5 +1,6 @@
 import { Sema } from "async-sema";
 import rpc, { values } from "./rpc";
+import createTable from "./createTable";
 import getTableData from "./getTableData";
 import { getPostPreview } from "./getPostPreview";
 import { readFile, writeFile } from "../fs-helpers";
@@ -35,11 +36,19 @@ export default async function getBlogIndex(previews = true) {
 
       postsTable = await getTableData(tableBlock, true);
     } catch (err) {
-      console.error(
-        `\nFailed to load Notion posts, did you configure your Notion table as an inline table according to https://github.com/ijjk/notion-blog#creating-your-pages-table\n`
+      console.warn(
+        `Failed to load Notion posts, attempting to auto create table`
       );
-      console.error(err);
-      postsTable = {};
+      try {
+        await createTable();
+        console.log(`Successfully created table in Notion`);
+      } catch (err) {
+        console.error(
+          `Auto creating table failed, make sure you created a blank page and site the id with BLOG_INDEX_ID in your environment`,
+          err
+        );
+      }
+      return {};
     }
 
     // only get 10 most recent post's previews

--- a/lib/notion/getNotionAssetUrls.ts
+++ b/lib/notion/getNotionAssetUrls.ts
@@ -1,0 +1,40 @@
+import fetch from "node-fetch";
+import { getError } from "./rpc";
+import { NextApiResponse } from "next";
+import { NOTION_TOKEN, API_ENDPOINT } from "./server-constants";
+
+export default async function getNotionAsset(
+  res: NextApiResponse,
+  assetUrl: string,
+  blockId: string
+): Promise<{
+  signedUrls: string[];
+}> {
+  const requestURL = `${API_ENDPOINT}/getSignedFileUrls`;
+  const assetRes = await fetch(requestURL, {
+    method: "POST",
+    headers: {
+      cookie: `token_v2=${NOTION_TOKEN}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      urls: [
+        {
+          url: assetUrl,
+          permissionRecord: {
+            table: "block",
+            id: blockId
+          }
+        }
+      ]
+    })
+  });
+
+  if (assetRes.ok) {
+    return assetRes.json();
+  } else {
+    console.log("bad request", assetRes.status);
+    res.json({ status: "error", message: "failed to load Notion asset" });
+    throw new Error(await getError(assetRes));
+  }
+}

--- a/lib/notion/getNotionUsers.ts
+++ b/lib/notion/getNotionUsers.ts
@@ -1,0 +1,25 @@
+import rpc from "./rpc";
+
+export default async function getNotionUsers(ids: string[]) {
+  const { results = [] } = await rpc("getRecordValues", {
+    requests: ids.map((id: string) => ({
+      id,
+      table: "notion_user"
+    }))
+  });
+
+  const users: any = {};
+
+  for (const result of results) {
+    const { value } = result || { value: {} };
+    const { given_name, family_name } = value;
+    let full_name = given_name || "";
+
+    if (family_name) {
+      full_name = `${full_name} ${family_name}`;
+    }
+    users[value.id] = { full_name };
+  }
+
+  return { users };
+}

--- a/lib/notion/getPageData.ts
+++ b/lib/notion/getPageData.ts
@@ -1,15 +1,20 @@
 import rpc, { values } from "./rpc";
 
 export default async function getPageData(pageId: string) {
-  const data = await loadPageChunk({ pageId });
-  const blocks = values(data.recordMap.block);
+  try {
+    const data = await loadPageChunk({ pageId });
+    const blocks = values(data.recordMap.block);
 
-  if (blocks[0] && blocks[0].value.content) {
-    // remove table blocks
-    blocks.splice(0, 3);
+    if (blocks[0] && blocks[0].value.content) {
+      // remove table blocks
+      blocks.splice(0, 3);
+    }
+
+    return { blocks };
+  } catch (err) {
+    console.error(`Failed to load pageData for ${pageId}`, err);
+    return { blocks: [] };
   }
-
-  return { blocks };
 }
 
 export function loadPageChunk({

--- a/lib/notion/getPageData.ts
+++ b/lib/notion/getPageData.ts
@@ -1,0 +1,29 @@
+import rpc, { values } from "./rpc";
+
+export default async function getPageData(pageId: string) {
+  const data = await loadPageChunk({ pageId });
+  const blocks = values(data.recordMap.block);
+
+  if (blocks[0] && blocks[0].value.content) {
+    // remove table blocks
+    blocks.splice(0, 3);
+  }
+
+  return { blocks };
+}
+
+export function loadPageChunk({
+  pageId,
+  limit = 100,
+  cursor = { stack: [] },
+  chunkNumber = 0,
+  verticalColumns = false
+}: any) {
+  return rpc("loadPageChunk", {
+    pageId,
+    limit,
+    cursor,
+    chunkNumber,
+    verticalColumns
+  });
+}

--- a/lib/notion/getPostPreview.ts
+++ b/lib/notion/getPostPreview.ts
@@ -1,0 +1,29 @@
+import { loadPageChunk } from "./getPageData";
+import { values } from "./rpc";
+
+const nonPreviewTypes = new Set(["editor", "page", "collection_view"]);
+
+export async function getPostPreview(pageId: string) {
+  let blocks;
+  let dividerIndex = 0;
+
+  const data = await loadPageChunk({ pageId, limit: 10 });
+  blocks = values(data.recordMap.block);
+
+  for (let i = 0; i < blocks.length; i++) {
+    if (blocks[i].value.type === "divider") {
+      dividerIndex = i;
+      break;
+    }
+  }
+
+  blocks = blocks
+    .splice(0, dividerIndex)
+    .filter(
+      ({ value: { type, properties } }: any) =>
+        !nonPreviewTypes.has(type) && properties
+    )
+    .map((block: any) => block.value.properties.title);
+
+  return blocks;
+}

--- a/lib/notion/getTableData.ts
+++ b/lib/notion/getTableData.ts
@@ -1,7 +1,10 @@
 import { values } from "./rpc";
 import queryCollection from "./queryCollection";
+import Slugger from "github-slugger";
 
 export default async function loadTable(collectionBlock: any, isPosts = false) {
+  const slugger = new Slugger();
+
   const { value } = collectionBlock;
   let table: any = {};
   const col = await queryCollection({
@@ -52,9 +55,12 @@ export default async function loadTable(collectionBlock: any, isPosts = false) {
             // start_time: 07:00
             // time_zone: Europe/Berlin, America/Los_Angeles
 
+            if (!type[1].start_date) {
+              break;
+            }
             // initial with provided date
             const providedDate = new Date(
-              type[1].start_date + " " + type[1].start_time
+              type[1].start_date + " " + (type[1].start_time || "")
             ).getTime();
 
             // calculate offset from provided time zone
@@ -79,6 +85,9 @@ export default async function loadTable(collectionBlock: any, isPosts = false) {
       }
       row[schema[key].name] = val || null;
     });
+
+    // auto-generate slug from title
+    row.Slug = row.Slug || slugger.slug(row.Page || "");
 
     const key = row.Slug;
     if (isPosts && !key) continue;

--- a/lib/notion/getTableData.ts
+++ b/lib/notion/getTableData.ts
@@ -1,0 +1,94 @@
+import { values } from "./rpc";
+import queryCollection from "./queryCollection";
+
+export default async function loadTable(collectionBlock: any, isPosts = false) {
+  const { value } = collectionBlock;
+  let table: any = {};
+  const col = await queryCollection({
+    collectionId: value.collection_id,
+    collectionViewId: value.view_ids[0]
+  });
+  const entries = values(col.recordMap.block).filter((block: any) => {
+    return block.value && block.value.parent_id === value.collection_id;
+  });
+
+  const colId = Object.keys(col.recordMap.collection)[0];
+  const schema = col.recordMap.collection[colId].value.schema;
+  const schemaKeys = Object.keys(schema);
+
+  for (const entry of entries) {
+    const props = entry.value && entry.value.properties;
+    const row: any = {};
+
+    if (!props) continue;
+    if (entry.value.content) {
+      row.id = entry.value.id;
+    }
+
+    schemaKeys.forEach(key => {
+      // might be undefined
+      let val = props[key] && props[key][0][0];
+
+      // authors and blocks are centralized
+      if (val && props[key][0][1]) {
+        const type = props[key][0][1][0];
+
+        switch (type[0]) {
+          case "a": // link
+            val = type[1];
+            break;
+          case "u": // user
+            val = props[key]
+              .filter((arr: any[]) => arr.length > 1)
+              .map((arr: any[]) => arr[1][0][1]);
+            break;
+          case "p": // page (block)
+            const page = col.recordMap.block[type[1]];
+            row.id = page.value.id;
+            val = page.value.properties.title[0][0];
+            break;
+          case "d": // date
+            // start_date: 2019-06-18
+            // start_time: 07:00
+            // time_zone: Europe/Berlin, America/Los_Angeles
+
+            // initial with provided date
+            const providedDate = new Date(
+              type[1].start_date + " " + type[1].start_time
+            ).getTime();
+
+            // calculate offset from provided time zone
+            const timezoneOffset =
+              new Date(
+                new Date().toLocaleString("en-US", {
+                  timeZone: type[1].time_zone
+                })
+              ).getTime() - new Date().getTime();
+
+            // initialize subtracting time zone offset
+            val = new Date(providedDate - timezoneOffset).getTime();
+            break;
+          default:
+            console.error("unknown type", type[0], type);
+            break;
+        }
+      }
+
+      if (typeof val === "string") {
+        val = val.trim();
+      }
+      row[schema[key].name] = val || null;
+    });
+
+    const key = row.Slug;
+    if (isPosts && !key) continue;
+
+    if (key) {
+      table[key] = row;
+    } else {
+      if (!Array.isArray(table)) table = [];
+      table.push(row);
+    }
+  }
+  return table;
+}

--- a/lib/notion/getTableData.ts
+++ b/lib/notion/getTableData.ts
@@ -1,6 +1,7 @@
 import { values } from "./rpc";
-import queryCollection from "./queryCollection";
 import Slugger from "github-slugger";
+import { normalizeSlug } from "../blog-helpers";
+import queryCollection from "./queryCollection";
 
 export default async function loadTable(collectionBlock: any, isPosts = false) {
   const slugger = new Slugger();
@@ -87,7 +88,7 @@ export default async function loadTable(collectionBlock: any, isPosts = false) {
     });
 
     // auto-generate slug from title
-    row.Slug = row.Slug || slugger.slug(row.Page || "");
+    row.Slug = normalizeSlug(row.Slug || slugger.slug(row.Page || ""));
 
     const key = row.Slug;
     if (isPosts && !key) continue;

--- a/lib/notion/queryCollection.ts
+++ b/lib/notion/queryCollection.ts
@@ -1,0 +1,49 @@
+import rpc from "./rpc";
+
+export default function queryCollection({
+  collectionId,
+  collectionViewId,
+  loader = {},
+  query = {}
+}: any) {
+  const {
+    limit = 999, // TODO: figure out Notion's way of handling pagination
+    loadContentCover = true,
+    type = "table",
+    userLocale = "en",
+    userTimeZone = "America/Phoenix"
+  } = loader;
+
+  const {
+    aggregate = [
+      {
+        aggregation_type: "count",
+        id: "count",
+        property: "title",
+        type: "title",
+        view_type: "table"
+      }
+    ],
+    filter = [],
+    filter_operator = "and",
+    sort = []
+  } = query;
+
+  return rpc("queryCollection", {
+    collectionId,
+    collectionViewId,
+    loader: {
+      limit,
+      loadContentCover,
+      type,
+      userLocale,
+      userTimeZone
+    },
+    query: {
+      aggregate,
+      filter,
+      filter_operator,
+      sort
+    }
+  });
+}

--- a/lib/notion/renderers.ts
+++ b/lib/notion/renderers.ts
@@ -1,0 +1,41 @@
+import React from "react";
+import components from "../../components/shared";
+
+function applyTags(tags = [], children, noPTag = false, key) {
+  let child = children;
+
+  for (const tag of tags) {
+    const props: { [key: string]: any } = { key };
+    let tagName = tag[0];
+
+    if (noPTag && tagName === "p") tagName = React.Fragment;
+    if (tagName === "c") tagName = "code";
+
+    if (tagName === "a") {
+      props.href = tag[1];
+    }
+
+    child = React.createElement(components[tagName] || tagName, props, child);
+  }
+  return child;
+}
+
+export function textBlock(text = [], noPTag = false, mainKey) {
+  const children = [];
+  let key = 0;
+
+  for (const textItem of text) {
+    key++;
+    if (textItem.length === 1) {
+      children.push(textItem);
+      continue;
+    }
+    children.push(applyTags(textItem[1], textItem[0], noPTag, key));
+  }
+  return React.createElement(
+    noPTag ? React.Fragment : components.p,
+    { key: mainKey } as any,
+    ...children,
+    noPTag
+  );
+}

--- a/lib/notion/rpc.ts
+++ b/lib/notion/rpc.ts
@@ -1,0 +1,49 @@
+import fetch, { Response } from "node-fetch";
+import { API_ENDPOINT, NOTION_TOKEN } from "./server-constants";
+
+export default async function rpc(fnName: string, body: any) {
+  if (!NOTION_TOKEN) {
+    throw new Error("NOTION_TOKEN is not set in env");
+  }
+  const res = await fetch(`${API_ENDPOINT}/${fnName}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: `token_v2=${NOTION_TOKEN}`
+    },
+    body: JSON.stringify(body)
+  });
+
+  if (res.ok) {
+    return res.json();
+  } else {
+    throw new Error(await getError(res));
+  }
+}
+
+export async function getError(res: Response) {
+  return `Notion API error (${res.status}) \n${getJSONHeaders(
+    res
+  )}\n ${await getBodyOrNull(res)}`;
+}
+
+export function getJSONHeaders(res: Response) {
+  return JSON.stringify(res.headers.raw());
+}
+
+export function getBodyOrNull(res: Response) {
+  try {
+    return res.text();
+  } catch (err) {
+    return null;
+  }
+}
+
+export function values(obj: any) {
+  const vals: any = [];
+
+  Object.keys(obj).forEach(key => {
+    vals.push(obj[key]);
+  });
+  return vals;
+}

--- a/lib/notion/server-constants.ts
+++ b/lib/notion/server-constants.ts
@@ -1,6 +1,19 @@
 import path from "path";
 
+const normalizeId = id => {
+  if (id.length === 36) return id;
+  if (id.length !== 32) {
+    throw new Error(
+      `Invalid blog-index-id: ${id} should be 32 characters long. Info here https://github.com/ijjk/notion-blog#getting-blog-index-and-token`
+    );
+  }
+  return `${id.substr(0, 8)}-${id.substr(8, 4)}-${id.substr(12, 4)}-${id.substr(
+    16,
+    4
+  )}-${id.substr(20)}`;
+};
+
 export const NOTION_TOKEN = process.env.NOTION_TOKEN;
-export const BLOG_INDEX_ID = process.env.BLOG_INDEX_ID;
+export const BLOG_INDEX_ID = normalizeId(process.env.BLOG_INDEX_ID);
 export const API_ENDPOINT = "https://www.notion.so/api/v3";
 export const BLOG_INDEX_CACHE = path.resolve(".blog_index_data");

--- a/lib/notion/server-constants.ts
+++ b/lib/notion/server-constants.ts
@@ -1,0 +1,6 @@
+import path from "path";
+
+export const NOTION_TOKEN = process.env.NOTION_TOKEN;
+export const BLOG_INDEX_ID = process.env.BLOG_INDEX_ID;
+export const API_ENDPOINT = "https://www.notion.so/api/v3";
+export const BLOG_INDEX_CACHE = path.resolve(".blog_index_data");

--- a/lib/notion/utils.ts
+++ b/lib/notion/utils.ts
@@ -1,0 +1,30 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+export function setHeaders(req: NextApiRequest, res: NextApiResponse): boolean {
+  // set SPR/CORS headers
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Cache-Control", "s-maxage=1, stale-while-revalidate");
+  res.setHeader("Access-Control-Allow-Methods", "GET");
+  res.setHeader("Access-Control-Allow-Headers", "pragma");
+
+  if (req.method === "OPTIONS") {
+    res.status(200);
+    res.end();
+    return true;
+  }
+  return false;
+}
+
+export async function handleData(res: NextApiResponse, data: any) {
+  data = data || { status: "error", message: "unhandled request" };
+  res.status(data.status !== "error" ? 200 : 500);
+  res.json(data);
+}
+
+export function handleError(res: NextApiResponse, error: string | Error) {
+  console.error(error);
+  res.status(500).json({
+    status: "error",
+    message: "an error occurred processing request"
+  });
+}

--- a/lib/use-mounted.js
+++ b/lib/use-mounted.js
@@ -1,0 +1,11 @@
+import { useState, useEffect } from 'react'
+
+export default function useMounted() {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  return mounted
+}

--- a/lib/with-views.js
+++ b/lib/with-views.js
@@ -2,7 +2,7 @@ import React from "react";
 
 // TODO: refactor into `useViews()`
 
-const withViews = fn =>
+const withViews = Comp =>
   class extends React.Component {
     constructor(props) {
       super(props);
@@ -59,7 +59,7 @@ const withViews = fn =>
     }
 
     render() {
-      return fn(this.state);
+      return <Comp {...this.state} {...this.props} />;
     }
   };
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,60 @@
+const fs = require("fs");
+const path = require("path");
+const { NODE_ENV, NOTION_TOKEN, BLOG_INDEX_ID } = process.env;
+
+try {
+  fs.unlinkSync(path.resolve(".blog_index_data"));
+} catch (_) {
+  /* non fatal */
+}
+try {
+  fs.unlinkSync(path.resolve(".blog_index_data_previews"));
+} catch (_) {
+  /* non fatal */
+}
+
+const warnOrError =
+  NODE_ENV !== "production"
+    ? console.warn
+    : msg => {
+        throw new Error(msg);
+      };
+
+if (!NOTION_TOKEN) {
+  // We aren't able to build or serve images from Notion without the
+  // NOTION_TOKEN being populated
+  warnOrError(
+    `\nNOTION_TOKEN is missing from env, this will result in an error\n` +
+      `Make sure to provide one before starting Next.js`
+  );
+}
+
+if (!BLOG_INDEX_ID) {
+  // We aren't able to build or serve images from Notion without the
+  // NOTION_TOKEN being populated
+  warnOrError(
+    `\nBLOG_INDEX_ID is missing from env, this will result in an error\n` +
+      `Make sure to provide one before starting Next.js`
+  );
+}
+
+module.exports = {
+  target: "experimental-serverless-trace",
+
+  experimental: {
+    css: true
+  },
+
+  webpack(cfg, { dev, isServer }) {
+    // only compile build-rss in production server build
+    if (dev || !isServer) return cfg;
+
+    const originalEntry = cfg.entry;
+    cfg.entry = async () => {
+      const entries = { ...(await originalEntry()) };
+      entries["./scripts/build-rss.js"] = "./lib/atom.js";
+      return entries;
+    };
+    return cfg;
+  }
+};

--- a/now.json
+++ b/now.json
@@ -2,7 +2,15 @@
   "env": {
     "FIREBASE_PROJECT_ID": "rauchg-blog",
     "FIREBASE_PRIVATE_KEY": "@blog-firebase-private-key",
-    "FIREBASE_CLIENT_EMAIL": "@blog-firebase-client-email"
+    "FIREBASE_CLIENT_EMAIL": "@blog-firebase-client-email",
+    "NOTION_TOKEN": "@notion-token",
+    "BLOG_INDEX_ID": "@blog-index-id"
+  },
+  "build": {
+    "env": {
+      "NOTION_TOKEN": "@notion-token",
+      "BLOG_INDEX_ID": "@blog-index-id"
+    }
   },
   "routes": [
     {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^16.12.0",
     "react-twitter-embed": "^3.0.3",
     "react-youtube": "^7.4.0",
+    "swr": "^0.1.16",
     "time-ago": "^0.2.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "rauchg-blog",
   "description": "rauchg.com (blog)",
   "dependencies": {
+    "@zeit/react-jsx-parser": "^2.0.0",
     "comma-number": "^2.0.0",
     "firebase": "^7.6.1",
     "firebase-admin": "^8.9.0",
     "load-script": "^1.0.0",
-    "next": "^9.1.7-canary.12",
+    "next": "^9.1.8-canary.5",
     "nprogress": "^0.2.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
@@ -17,5 +18,9 @@
   "scripts": {
     "dev": "next",
     "build": "next build && node scripts/build-atom > public/atom"
+  },
+  "devDependencies": {
+    "@types/react": "^16.9.17",
+    "typescript": "^3.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "comma-number": "^2.0.0",
     "firebase": "^7.6.1",
     "firebase-admin": "^8.9.0",
+    "github-slugger": "^1.2.1",
     "load-script": "^1.0.0",
     "next": "^9.1.8-canary.5",
     "nprogress": "^0.2.0",

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -1,0 +1,223 @@
+import React from "react";
+import ReactJSXParser from "@zeit/react-jsx-parser";
+import { textBlock } from "../lib/notion/renderers";
+import getPageData from "../lib/notion/getPageData";
+import getBlogIndex from "../lib/notion/getBlogIndex";
+import { getBlogLink, getDateStr, getHeadingId } from "../lib/blog-helpers";
+
+import Head from "next/head";
+import withViews from "../lib/with-views";
+import Post from "../components/layouts/post";
+import Header from "../components/post/header";
+import components from "../components/shared";
+
+// Get the data for each blog post
+export async function unstable_getStaticProps({ params: { slug } }) {
+  // load the postsTable so that we can get the page's ID
+  const postsTable = await getBlogIndex();
+  const post = postsTable[slug];
+
+  if (!post) {
+    console.log(`Failed to find post for slug: ${slug}`);
+    return {
+      props: {
+        redirect: true
+      }
+    };
+  }
+  const postData = await getPageData(post.id);
+  post.content = postData.blocks;
+
+  return {
+    props: {
+      post
+    }
+  };
+}
+
+// Return our list of blog posts to prerender
+export async function unstable_getStaticPaths() {
+  const postsTable = await getBlogIndex();
+  return Object.keys(postsTable).map(slug => getBlogLink(slug));
+}
+
+const listTypes = new Set(["bulleted_list", "numbered_list"]);
+
+const RenderPost = ({ post, views, redirect }) => {
+  let listTagName = null;
+  let listLastId = null;
+  let listChildren = [];
+
+  if (redirect) {
+    return (
+      <>
+        <Head>
+          <meta name="robots" content="noindex" />
+          <meta httpEquiv="refresh" content={`0;url=https://rauchg.com`} />
+        </Head>
+      </>
+    );
+  }
+
+  return (
+    <Post>
+      <Header title={post.Page} date={getDateStr(post.Date)} views={views} />
+      <Head>
+        <meta property="og:title" content={post.Page} />
+        <meta property="og:site_name" content="Guillermo Rauch's blog" />
+        <meta property="og:description" content={post.Description} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@rauchg" />
+        <meta property="og:image" content={post["Twitter Card"] || ""} />
+      </Head>
+
+      {post.content.map((block, blockIdx) => {
+        const { value } = block;
+        const { type, properties, id } = value;
+        const isLast = blockIdx === post.content.length - 1;
+        const isList = listTypes.has(type);
+        let toRender = [];
+
+        if (isList) {
+          listTagName = components[type === "bulleted_list" ? "ul" : "ol"];
+          listLastId = `list${id}`;
+          listChildren.push(
+            React.createElement(
+              components.li || "li",
+              { key: id },
+              textBlock(properties.title, true, id)
+            )
+          );
+        }
+
+        if (listTagName && (isLast || !isList)) {
+          toRender.push(
+            React.createElement(
+              listTagName,
+              { key: listLastId },
+              ...listChildren
+            )
+          );
+          listChildren = [];
+          listLastId = null;
+          listTagName = null;
+        }
+
+        const renderHeading = Type => {
+          const children = textBlock(properties.title, true, id);
+          const headingId =
+            type !== "string" ? getHeadingId(children) : undefined;
+
+          toRender.push(
+            <Type key={id} id={headingId}>
+              {children}
+            </Type>
+          );
+        };
+
+        switch (type) {
+          case "page":
+          case "divider":
+            break;
+          case "text":
+            if (properties) {
+              toRender.push(textBlock(properties.title, false, id));
+            }
+            break;
+          case "image":
+          case "video": {
+            const { format = {} } = value;
+            const { block_width } = format;
+            const baseBlockWidth = 768;
+            const roundFactor = Math.pow(10, 2);
+            // calculate percentages
+            const width = block_width
+              ? `${Math.round(
+                  (block_width / baseBlockWidth) * 100 * roundFactor
+                ) / roundFactor}%`
+              : "100%";
+
+            const isImage = type === "image";
+            const Comp = isImage ? "img" : "video";
+
+            toRender.push(
+              <Comp
+                key={id}
+                src={`/api/asset?assetUrl=${encodeURIComponent(
+                  format.display_source
+                )}&blockId=${id}`}
+                controls={!isImage}
+                alt={isImage ? "An image from Notion" : undefined}
+                loop={!isImage}
+                muted={!isImage}
+                autoPlay={!isImage}
+                style={{
+                  boxShadow: "0 8px 8px rgba(0, 0, 0, 0.3)",
+                  width,
+                  maxWidth: "100%",
+                  margin: "5px auto",
+                  display: "block"
+                }}
+              />
+            );
+            break;
+          }
+          case "header":
+            renderHeading("h1");
+            break;
+          case "sub_header":
+            renderHeading(components.h2);
+            break;
+          case "sub_sub_header":
+            renderHeading(components.h3);
+            break;
+          case "code": {
+            if (properties.title) {
+              const content = properties.title[0][0];
+              const language = properties.language[0][0];
+
+              if (language === "LiveScript") {
+                // this requires the DOM for now
+                toRender.push(
+                  <ReactJSXParser
+                    key={id}
+                    jsx={content}
+                    components={components}
+                    componentsOnly={false}
+                    renderInpost={false}
+                    allowUnknownElements={true}
+                    blacklistedTags={["script", "style"]}
+                  />
+                );
+              } else {
+                toRender.push(
+                  <components.Code key={id}>{content}</components.Code>
+                );
+              }
+            }
+            break;
+          }
+          case "quote":
+            if (properties.title) {
+              toRender.push(
+                React.createElement(components.blockquote, {
+                  key: id,
+                  by: "",
+                  children: properties.title
+                })
+              );
+            }
+            break;
+          default:
+            if (process.env.NODE_ENV !== "production" && !listTypes.has(type)) {
+              console.log("unknown type", type);
+            }
+            break;
+        }
+        return toRender;
+      })}
+    </Post>
+  );
+};
+
+export default withViews(RenderPost);

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -14,6 +14,7 @@ import components from "../components/shared";
 
 // Get the data for each blog post
 export async function unstable_getStaticProps({ params: { slug } }) {
+  slug = Array.isArray(slug) ? slug.join('/') : slug
   // load the postsTable so that we can get the page's ID
   const postsTable = await getBlogIndex();
   const post = postsTable[slug];

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -76,7 +76,11 @@ const RenderPost = ({ post, views, redirect }) => {
         <meta property="og:image" content={post["Twitter Card"] || ""} />
       </Head>
 
-      {post.content.map((block, blockIdx) => {
+      {(!post.content || post.content.length === 0) && (
+        <components.p>This post has no content</components.p>
+      )}
+
+      {(post.content || []).map((block, blockIdx) => {
         const { value } = block;
         const { type, properties, id } = value;
         const isLast = blockIdx === post.content.length - 1;

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -3,6 +3,7 @@ import ReactJSXParser from "@zeit/react-jsx-parser";
 import { textBlock } from "../lib/notion/renderers";
 import getPageData from "../lib/notion/getPageData";
 import getBlogIndex from "../lib/notion/getBlogIndex";
+import IssgIndicator from '../components/issg-indicator';
 import { getBlogLink, getDateStr, getHeadingId } from "../lib/blog-helpers";
 
 import Head from "next/head";
@@ -22,7 +23,8 @@ export async function unstable_getStaticProps({ params: { slug } }) {
     return {
       props: {
         redirect: true
-      }
+      },
+      revalidate: 1
     };
   }
   const postData = await getPageData(post.id);
@@ -31,7 +33,8 @@ export async function unstable_getStaticProps({ params: { slug } }) {
   return {
     props: {
       post
-    }
+    },
+    revalidate: 2,
   };
 }
 
@@ -61,6 +64,8 @@ const RenderPost = ({ post, views, redirect }) => {
 
   return (
     <Post>
+      <IssgIndicator />
+
       <Header title={post.Page} date={getDateStr(post.Date)} views={views} />
       <Head>
         <meta property="og:title" content={post.Page} />

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1,0 +1,19 @@
+import useMounted from "../lib/use-mounted"
+import { useEffect, useState } from "react"
+
+export default () => {
+  const mounted = useMounted()
+  const [enabled, setEnabled] = useState(mounted && localStorage.issgIndicator)
+
+  useEffect(() => {
+    setEnabled(localStorage.issgIndicator)
+  }, [mounted])
+
+  return (
+    <button onClick={() => {
+      if (enabled) delete localStorage.issgIndicator
+      else localStorage.issgIndicator = true
+      setEnabled(localStorage.issgIndicator)
+    }}>{enabled ? 'Disable' : 'Enable'} indicator</button>
+  )
+}

--- a/pages/api/asset.ts
+++ b/pages/api/asset.ts
@@ -1,0 +1,41 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import getNotionAssetUrls from "../../lib/notion/getNotionAssetUrls";
+import { setHeaders, handleData, handleError } from "../../lib/notion/utils";
+
+export default async function notionApi(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (setHeaders(req, res)) return;
+  try {
+    const { assetUrl, blockId } = req.query as { [k: string]: string };
+
+    if (!assetUrl || !blockId) {
+      handleData(res, {
+        status: "error",
+        message: "asset url or blockId missing"
+      });
+    } else {
+      // we need to re-encode it since it's decoded when added to req.query
+      const { signedUrls = [], ...urlsResponse } = await getNotionAssetUrls(
+        res,
+        assetUrl,
+        blockId
+      );
+
+      if (signedUrls.length === 0) {
+        console.error("Failed to get signedUrls", urlsResponse);
+        return handleData(res, {
+          status: "error",
+          message: "Failed to get asset URL"
+        });
+      }
+
+      res.status(307);
+      res.setHeader("Location", signedUrls.pop());
+      res.end();
+    }
+  } catch (error) {
+    handleError(res, error);
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,26 +1,23 @@
 import Layout from "../components/layouts/main";
 import Link from "next/link";
-import { posts } from "../posts";
 import { WRITINGS } from "../components/header";
+import getCombinedPosts from "../lib/get-combined-posts";
 
-export function unstable_getStaticProps() {
+export async function unstable_getStaticProps() {
   return {
     props: {
-      posts: posts.map(post => ({
-        ...post,
-        url: `${new Date(post.date).getFullYear()}/${post.id}`
-      }))
+      posts: await getCombinedPosts()
     }
   };
 }
 
-const Home = ({ posts, date }) => (
+const Home = ({ posts }) => (
   <Layout headerActive={WRITINGS}>
     <ul>
       {posts.map(post => (
         <li key={post.id}>
           <span>{post.date}</span>
-          <Link href={post.url}>
+          <Link href={post.notion ? "[...slug]" : post.url} as={post.url}>
             <a>{post.title}</a>
           </Link>
         </li>

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,12 +2,14 @@ import Layout from "../components/layouts/main";
 import Link from "next/link";
 import { WRITINGS } from "../components/header";
 import getCombinedPosts from "../lib/get-combined-posts";
+import IssgIndicator from '../components/issg-indicator';
 
 export async function unstable_getStaticProps() {
   return {
     props: {
       posts: await getCombinedPosts()
-    }
+    },
+    revalidate: 2
   };
 }
 
@@ -23,6 +25,8 @@ const Home = ({ posts }) => (
         </li>
       ))}
     </ul>
+
+    <IssgIndicator />
 
     <style jsx>{`
       ul li {

--- a/scripts/build-atom
+++ b/scripts/build-atom
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
-const atom = require("../lib/atom");
-console.log(atom());
+const atom = require("../.next/serverless/scripts/build-rss").default;
+atom().then(result => console.log(result))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,6 +1268,19 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.59.tgz#9e34261f30183f9777017a13d185dfac6b899e04"
   integrity sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@^16.9.17":
+  version "16.9.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.17.tgz#58f0cc0e9ec2425d1441dd7b623421a867aa253e"
+  integrity sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -1424,6 +1437,13 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zeit/react-jsx-parser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@zeit/react-jsx-parser/-/react-jsx-parser-2.0.0.tgz#d9261be2c8e3024cf355c69569ef3f355805d903"
+  integrity sha512-aMt6Je4XRpy9QrUnaauVd1EmWYrvj6Din7iFu83p1N1g18eUhGuyCwi6h5JR/DFIpsOO8YXl1jfYtM2Xo/mBRQ==
+  dependencies:
+    acorn-jsx "^4.1.1"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1443,6 +1463,18 @@ accepts@~1.3.5:
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
+
+acorn-jsx@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
+  integrity sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==
+  dependencies:
+    acorn "^5.0.3"
+
+acorn@^5.0.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
 acorn@^6.2.1:
   version "6.4.0"
@@ -1932,6 +1964,15 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+browserslist@4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.3.tgz#65802fcd77177c878e015f0e3189f2c4f627ba44"
+  integrity sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==
+  dependencies:
+    caniuse-lite "^1.0.30001017"
+    electron-to-chromium "^1.3.322"
+    node-releases "^1.1.44"
+
 browserslist@^4.6.0, browserslist@^4.6.4, browserslist@^4.8.0, browserslist@^4.8.2:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.2.tgz#b45720ad5fbc8713b7253c20766f701c9a694289"
@@ -2080,6 +2121,11 @@ caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.300010
   version "1.0.30001016"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz#16ea48d7d6e8caf3cad3295c2d746fe38c4e7f66"
   integrity sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==
+
+caniuse-lite@^1.0.30001017:
+  version "1.0.30001019"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001019.tgz#857e3fccaad2b2feb3f1f6d8a8f62d747ea648e1"
+  integrity sha512-6ljkLtF1KM5fQ+5ZN0wuyVvvebJxgJPTmScOMaFuQN2QuOzvRJnWSKfzQskQU5IOU4Gap3zasYPIinzwUjoj/g==
 
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -2542,6 +2588,11 @@ cssnano-simple@1.0.0:
   dependencies:
     cssnano-preset-simple "^1.0.0"
     postcss "^7.0.18"
+
+csstype@^2.2.0:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
+  integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -4665,10 +4716,10 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-next@^9.1.7-canary.12:
-  version "9.1.7-canary.12"
-  resolved "https://registry.yarnpkg.com/next/-/next-9.1.7-canary.12.tgz#a6be0d6adfbe8f012142030b883c2840672c9a11"
-  integrity sha512-J+pBUInv9+lYDwHucPUpgKJAtW7/gN/cCgmO5ubBpLa5HKaUFIuPZTuXG1+n8ImRWwwPjzFG1P+rp/vWo/GaGw==
+next@^9.1.8-canary.5:
+  version "9.1.8-canary.5"
+  resolved "https://registry.yarnpkg.com/next/-/next-9.1.8-canary.5.tgz#e796c67edcb1309cafe084b835b8d76bfdd00e9f"
+  integrity sha512-vGSjPNVnKNhjmDs7iElz6xCBtf9AZ7BWPaxKzN+4I51msHQo8A+o59aWr2bH8CfHwKw8EzEKjprA+comFLG4yg==
   dependencies:
     "@ampproject/toolbox-optimizer" "1.1.1"
     "@babel/core" "7.7.2"
@@ -4694,6 +4745,7 @@ next@^9.1.7-canary.12:
     babel-plugin-syntax-jsx "6.18.0"
     babel-plugin-transform-define "2.0.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
+    browserslist "4.8.3"
     cache-loader "4.1.0"
     chalk "2.4.2"
     ci-info "2.0.0"
@@ -4822,7 +4874,7 @@ node-pre-gyp@^0.14.0:
     semver "^5.3.0"
     tar "^4.4.2"
 
-node-releases@^1.1.42:
+node-releases@^1.1.42, node-releases@^1.1.44:
   version "1.1.44"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.44.tgz#cd66438a6eb875e3eb012b6a12e48d9f4326ffd7"
   integrity sha512-NwbdvJyR7nrcGrXvKAvzc5raj/NkoJudkarh2yIpJ4t0NH4aqjUDz/486P+ynIW5eokKOfzGNRdYoLfBlomruw==
@@ -6848,6 +6900,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 unfetch@4.1.0:
   version "4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2827,6 +2827,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+"emoji-regex@>=6.0.0 <=6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
+  integrity sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -3392,6 +3397,13 @@ get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
+github-slugger@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.2.1.tgz#47e904e70bf2dccd0014748142d31126cfd49508"
+  integrity sha512-SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==
+  dependencies:
+    emoji-regex ">=6.0.0 <=6.1.1"
 
 glob-parent@^3.1.0:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,7 +3085,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-fast-deep-equal@^2.0.1:
+fast-deep-equal@2.0.1, fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
@@ -6718,6 +6718,13 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+swr@^0.1.16:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.1.16.tgz#e1667f2260ac091fb4c2cc6255ca1b8ff83b0acd"
+  integrity sha512-E+i0pJOCCPRxnwQMFKf3RYr4os+B4swNuwnHo+pBCNxwfuJiN0ZalwP9u4OqjoeMl9eZFgcQYUPHD8KVyTqM1g==
+  dependencies:
+    fast-deep-equal "2.0.1"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
This adds loading new posts from Notion for more seamless editing. Before it can be deployed the `notion-token` and `blog-index-id` secrets will need to be added and table created in Notion