### PR TITLE
Add Hreflang, add link to JP, minor tweaks

### DIFF
--- a/components/hreflang.js
+++ b/components/hreflang.js
@@ -1,0 +1,13 @@
+import Head from "next/head";
+
+export default function Hreflang({ links, defaultUrl }) {
+  return (
+    <Head>
+      {links.map(({ url, lang }) => (
+        <link rel="alternate" href={url} hrefLang={lang} key={lang} />
+      ))}
+      <link rel="alternate" href={defaultUrl} hrefLang="x-default" />
+      <link rel="alternate" href={defaultUrl} hrefLang="en" />
+    </Head>
+  );
+}

--- a/pages/2014/7-principles-of-rich-web-applications.js
+++ b/pages/2014/7-principles-of-rich-web-applications.js
@@ -33,8 +33,8 @@ export default withViews(({ views }) => (
         <a href={links[2]} target="_blank">
           Portuguese
         </a>
+        .
       </span>
-      .
     </P>
 
     <P>
@@ -1096,6 +1096,7 @@ So: the hardware of the Internet can currently achieve within a factor of two of
     <style jsx>{`
       .translations {
         color: #666;
+        font-size: 14px;
       }
     `}</style>
   </Post>

--- a/pages/2020/vercel.js
+++ b/pages/2020/vercel.js
@@ -12,6 +12,15 @@ import UL, { LI } from "../../components/post/bullets-list";
 import withViews from "../../lib/with-views";
 import YouTube from "../../components/post/youtube";
 import Head from "next/head";
+import Link from "next/link";
+import Hreflang from "../../components/hreflang";
+
+export const PostHrefLang = () => (
+  <Hreflang
+    links={[{ lang: "ja", url: "https://rauchg.com/ja/2020/vercel" }]}
+    defaultUrl="https://rauchg.com/2020/vercel"
+  />
+);
 
 export default withViews(({ views }) => (
   <Post>
@@ -27,6 +36,17 @@ export default withViews(({ views }) => (
       <meta name="twitter:site" content="@rauchg" />
       <meta property="og:image" content="https://rauchg.com/og/vercel.png" />
     </Head>
+    <PostHrefLang />
+
+    <P>
+      <span className="translations">
+        Also available in:{" "}
+        <Link href="/ja/2020/vercel">
+          <a>Japanese</a>
+        </Link>
+        .
+      </span>
+    </P>
 
     <P>
       Today we announced that we’ve re-branded as{" "}
@@ -330,5 +350,11 @@ export default withViews(({ views }) => (
       </a>
       , much like the platform it builds on.
     </P>
+    <style jsx>{`
+      .translations {
+        color: #666;
+        font-size: 14px;
+      }
+    `}</style>
   </Post>
 ));

--- a/pages/ja/2020/vercel.js
+++ b/pages/ja/2020/vercel.js
@@ -1,11 +1,12 @@
-import Post from '../../../components/layouts/post'
-import P from '../../../components/post/paragraph'
-import HR from '../../../components/post/hr'
-import Header from '../../../components/post/header'
-import { H2, H3 } from '../../../components/post/heading'
-import withViews from '../../../lib/with-views'
-import Head from 'next/head'
-import Link from 'next/link'
+import Post from "../../../components/layouts/post";
+import P from "../../../components/post/paragraph";
+import HR from "../../../components/post/hr";
+import Header from "../../../components/post/header";
+import { H2, H3 } from "../../../components/post/heading";
+import withViews from "../../../lib/with-views";
+import Head from "next/head";
+import Link from "next/link";
+import { PostHrefLang } from "../../2020/vercel";
 
 export default withViews(({ views }) => (
   <Post>
@@ -21,8 +22,9 @@ export default withViews(({ views }) => (
       <meta name="twitter:site" content="@rauchg" />
       <meta property="og:image" content="https://rauchg.com/og/vercel.png" />
     </Head>
+    <PostHrefLang />
     <P>
-      訳註:{' '}
+      訳註:{" "}
       <a href="https://nextjs.org/" target="_blank">
         Next.js
       </a>
@@ -175,7 +177,7 @@ export default withViews(({ views }) => (
       <a href="https://svelte.dev" target="_blank">
         Svelte
       </a>
-      はブラウザが読み込むJavaScriptの容量を大幅に減らすなど意欲的な試みを行っています。どのフレームワークも、コンポーネント化で直面する様々な問題や、
+      は、ブラウザが読み込むJavaScriptの容量を大幅に減らすなど意欲的な試みを行っています。どのフレームワークも、コンポーネント化で直面する様々な問題や、
       <a target="_blank" href="https://www.webcomponents.org/">
         コンポーネント化のウェブ標準
       </a>
@@ -188,7 +190,7 @@ export default withViews(({ views }) => (
       コードをプッシュしてレビューする一連のプロセスは複雑化しがちです。自前のCI/CDパイプラインを構築したり、Jenkinsの設定を弄ったり、CI/CDやCDNのベンダーを選定するのに時間がかかりすぎるのです。CI/CDとCDNをうまく連携させたり、複雑なシステムの挙動を見張るのはとても難儀です。
     </P>
     <P>
-      フロントエンドに特化したプッシュ・レビューの仕組みについて試行錯誤した結果、私達は画期的なアイデアにたどり着きました。フロントエンド開発チームにとっては、プレビュー用のURLほど強力な武器はないと気づいたのです。Vercelを使えば、開発中のフロントエンドアプリをプレビュー用にデプロイし、すぐさまそのURLを取得して結果を確認することができます。コンテンツ管理システム(訳註:
+      フロントエンドに特化したプッシュ・レビューの仕組みについて試行錯誤した結果、私達は画期的なアイデアにたどり着きました。Jamstackのフロントエンドアプリを開発しているチームにとっては、プレビュー用のURLほどシンプルで強力なものはないと気づいたのです。Vercelを使えば、開発中のフロントエンドアプリをプレビュー用にデプロイし、すぐさまそのURLを取得して結果を確認することができます。コンテンツ管理システム(訳註:
       Wordpressなど)によくあるプレビュー機能と同じですが、Vercelは
       <a href="https://vercel.com/github" target="_blank">
         <b>Gitと連携し、全てのpushに対してデプロイを行うのがポイントです</b>。
@@ -268,4 +270,4 @@ export default withViews(({ views }) => (
       な物語が垣間見えることでしょう。
     </P>
   </Post>
-))
+));


### PR DESCRIPTION
Follow-up to #42 

- Adds `Hreflang` (followed [Google's guidelines](https://support.google.com/webmasters/answer/189077?hl=en))
- Add links to JP page from EN page
- Prettier fixes
- Very minor language fix

Preview URL: https://blog-git-fork-chibicode-ja-vercel-squash.rauchg.now.sh/2020/vercel

![image](https://user-images.githubusercontent.com/992008/80240145-3f711700-8616-11ea-960a-5146a14f33db.png)
