### PR TITLE
fix(develop-preview-test article): heading anchors

### DIFF
--- a/pages/2020/develop-preview-test.js
+++ b/pages/2020/develop-preview-test.js
@@ -91,7 +91,7 @@ const Page = withViews(({ tweets, views }) => (
       how you can adopt this methodology in mere minutes.
     </P>
 
-    <H2>Why end-to-end?</H2>
+    <H2 id="why-end-to-end">Why end-to-end?</H2>
 
     <P>
       In addition to integration tests, I want to now make the case that modern
@@ -166,7 +166,7 @@ const Page = withViews(({ tweets, views }) => (
       (it must do the right thing quickly).
     </P>
 
-    <H2>End-to-end made possible</H2>
+    <H2 id="end-to-end-made-possible">End-to-end made possible</H2>
 
     <P>
       First, back when I argued for focusing on integration in 2016 and made no
@@ -262,7 +262,7 @@ const Page = withViews(({ tweets, views }) => (
       for an example) are <b>now making E2E both fast and cheap</b>.
     </P>
 
-    <H2>End-to-end made easy</H2>
+    <H2 id="end-to-end-made-easy">End-to-end made easy</H2>
 
     <P>
       To show the <b>Develop -> Preview -> Test</b> workflow in action, I'm
@@ -378,7 +378,7 @@ const Page = withViews(({ tweets, views }) => (
       />
     </Figure>
 
-    <H2>Conclusion</H2>
+    <H2 id="conclusion">Conclusion</H2>
 
     <P>
       Notably, Checkly allows us to configure multiple locations in the world


### PR DESCRIPTION
Previously they lead to a link which contained undefined like this:
`https://rauchg.com/2020/develop-preview-test#undefined`
Thats now fixed, for the future maybe throw an error if an heading will be used without an ID specified?