### PR TITLE
Use medium twitter image

### DIFF
--- a/static-tweet/components/twitter-layout/components/media.js
+++ b/static-tweet/components/twitter-layout/components/media.js
@@ -17,7 +17,7 @@ export const Img = ({ width, height, src, ...p }) => {
         >
           <Image
             {...p}
-            src={`${src}&name=small`}
+            src={`${src}&name=medium`}
             layout="fill"
             objectFit="cover"
             quality={80}


### PR DESCRIPTION
The small twitter image looks grainy on retina displays.

This PR changes the twitter embed to use the medium sized twitter image.

## Before
<img src="https://rauchg.com/_next/image?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FExMtnH7VkAUO51f%3Fformat%3Djpg%26name%3Dsmall&w=3840&q=80" width="600" />


## After
<img src="https://rauchg.com/_next/image?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FExMtnH7VkAUO51f%3Fformat%3Djpg%26name%3Dmedium&w=3840&q=80" width="600" />