### PR TITLE
use UPSTASH_REDIS_REST_URL instead of hardcoded URL

### DIFF
--- a/app/redis.ts
+++ b/app/redis.ts
@@ -5,7 +5,7 @@ if (!process.env.UPSTASH_REDIS_REST_TOKEN) {
 }
 
 const redis = new Redis({
-  url: "https://global-apt-bear-30602.upstash.io",
+  url: process.env.UPSTASH_REDIS_REST_URL,
   token: process.env.UPSTASH_REDIS_REST_TOKEN,
 });
 


### PR DESCRIPTION
This approach eases the process of environment-specific deployments as this URL isn't universal for all upstash configs.