### PR TITLE
Move bio to a client component

### DIFF
--- a/app/about/bio.tsx
+++ b/app/about/bio.tsx
@@ -1,0 +1,18 @@
+"use client";
+import Image from "next/image";
+
+export function Bio() {
+  return (
+    <a href="https://twitter.com/rauchg" target="_blank">
+      <Image
+        src="/images/rauchg-3d4cecf.jpg"
+        alt="Guillermo Rauch"
+        className="rounded-full bg-gray-100 block mt-2 mb-5 mx-auto sm:float-right sm:ml-5 sm:mb-5 grayscale hover:grayscale-0"
+        unoptimized
+        width={160}
+        height={160}
+        priority
+      />
+    </a>
+  );
+}

--- a/app/about/page.mdx
+++ b/app/about/page.mdx
@@ -1,18 +1,8 @@
-import Image from "next/image";
+import { Bio } from "./bio";
 
 # About
 
-<a href="https://twitter.com/rauchg" target="_blank">
-  <Image
-    src="/images/rauchg-3d4cecf.jpg"
-    alt="Guillermo Rauch"
-    className="rounded-full bg-gray-100 block mt-2 mb-5 mx-auto sm:float-right sm:ml-5 sm:mb-5 grayscale hover:grayscale-0"
-    unoptimized
-    width={160}
-    height={160}
-    priority
-  />
-</a>
+<Bio />
 
 I&rsquo;m a software engineer and CEO of Vercel. I&rsquo;m originally
 from Lanús, Buenos Aires, Argentina. I owe much of my career to the Web


### PR DESCRIPTION
This extracts the bio image into a client component to avoid the `Cannot access Image.propTypes on the server` error.

https://replay.run/YxMqF7R
https://www.loom.com/share/92dca366a49c44b7ae7e71e0b1998ff5