### PR TITLE
Refactor redis

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+UPSTASH_REDIS_REST_URL=https://global-apt-bear-30602.upstash.io

--- a/app/(post)/components/tweet.tsx
+++ b/app/(post)/components/tweet.tsx
@@ -6,7 +6,7 @@ import {
   TweetSkeleton,
   type TweetProps,
 } from "react-tweet";
-import redis from "@/app/redis";
+import { getTweet as getTweetFromRedis, setTweet } from "@/app/redis";
 import { Caption } from "./caption";
 import "./tweet.css";
 
@@ -23,14 +23,14 @@ async function getAndCacheTweet(id: string): Promise<Tweet | undefined> {
     // @ts-ignore
     if (tweet && !tweet.tombstone) {
       // we populate the cache if we have a fresh tweet
-      await redis.set(`tweet:${id}`, tweet);
+      await setTweet(id, tweet);
       return tweet;
     }
   } catch (error) {
     console.error("tweet fetch error", error);
   }
 
-  const cachedTweet: Tweet | null = await redis.get(`tweet:${id}`);
+  const cachedTweet = await getTweetFromRedis(id);
 
   // @ts-ignore
   if (!cachedTweet || cachedTweet.tombstone) return undefined;

--- a/app/(post)/header.tsx
+++ b/app/(post)/header.tsx
@@ -75,7 +75,12 @@ function Views({ id, mutate, defaultValue }) {
   const didLogViewRef = useRef(false);
 
   useEffect(() => {
-    if ("development" === process.env.NODE_ENV) return;
+    if (
+      "development" === process.env.NODE_ENV &&
+      !process.env.NEXT_PUBLIC_ENABLE_PAGE_VIEWS
+    )
+      return;
+
     if (!didLogViewRef.current) {
       const url = "/api/view?incr=1&id=" + encodeURIComponent(id);
       fetch(url)

--- a/app/api/view/route.ts
+++ b/app/api/view/route.ts
@@ -1,6 +1,6 @@
 export const runtime = "edge";
 
-import redis from "@/app/redis";
+import { incrView, getPageViews } from "@/app/redis";
 import postsData from "@/app/posts.json";
 import commaNumber from "comma-number";
 import { NextResponse } from "next/server";
@@ -37,14 +37,14 @@ export async function GET(req: NextRequest) {
   }
 
   if (url.searchParams.get("incr") != null) {
-    const views = await redis.hincrby("views", id, 1);
+    const views = await incrView(id);
     return NextResponse.json({
       ...post,
       views,
       viewsFormatted: commaNumber(views),
     });
   } else {
-    const views = (await redis.hget("views", id)) ?? 0;
+    const views = await getPageViews(id);
     return NextResponse.json({
       ...post,
       views,

--- a/app/get-posts.ts
+++ b/app/get-posts.ts
@@ -1,5 +1,5 @@
 import postsData from "./posts.json";
-import redis from "./redis";
+import { getViews } from "./redis";
 import commaNumber from "comma-number";
 
 export type Post = {
@@ -10,13 +10,8 @@ export type Post = {
   viewsFormatted: string;
 };
 
-// shape of the HSET in redis
-type Views = {
-  [key: string]: string;
-};
-
 export const getPosts = async () => {
-  const allViews: null | Views = await redis.hgetall("views");
+  const allViews = await getViews();
   const posts = postsData.posts.map((post): Post => {
     const views = Number(allViews?.[post.id] ?? 0);
     return {


### PR DESCRIPTION
This is a small dx change that makes it easier to get started.

The first thing you'll see is that all redis functions are moved to `redis.ts` which provides a public api which supports not having access to redis. This is a small thing, but if someone tries to clone and run the blog locally, it's marginally nicer for it to work the first time.

The second thing is a feature flag (`NEXT_PUBLIC_ENABLE_PAGE_VIEWS`) for enabling incrementing page views locally. This makes it easier to test incrementing page view logic locally without accidentally shipping commented out code.

https://replay.run/OAjMlT5
https://www.loom.com/share/6b9838e0f6aa45c29da61379e83ee290