### PR TITLE
Goodbye edge runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist
 .pnpm-debug.log
 TODO
 .env*.local
+fonts/*
+!fonts/init.mjs

--- a/app/(post)/og/[id]/route.tsx
+++ b/app/(post)/og/[id]/route.tsx
@@ -10,48 +10,22 @@ export async function generateStaticParams() {
 }
 
 // fonts
+const fontsDir = join(process.cwd(), "fonts");
+
 const inter300 = readFileSync(
-  join(
-    process.cwd(),
-    "node_modules",
-    "@fontsource",
-    "inter",
-    "files",
-    "inter-latin-300-normal.woff"
-  )
+  join(fontsDir, "inter-latin-300-normal.woff")
 );
 
 const inter500 = readFileSync(
-  join(
-    process.cwd(),
-    "node_modules",
-    "@fontsource",
-    "inter",
-    "files",
-    "inter-latin-500-normal.woff"
-  )
+  join(fontsDir, "inter-latin-500-normal.woff")
 );
 
 const inter600 = readFileSync(
-  join(
-    process.cwd(),
-    "node_modules",
-    "@fontsource",
-    "inter",
-    "files",
-    "inter-latin-600-normal.woff"
-  )
+  join(fontsDir, "inter-latin-600-normal.woff")
 );
 
 const robotoMono400 = readFileSync(
-  join(
-    process.cwd(),
-    "node_modules",
-    "@fontsource",
-    "roboto-mono",
-    "files",
-    "roboto-mono-latin-400-normal.woff"
-  )
+  join(fontsDir, "roboto-mono-latin-400-normal.woff")
 );
 
 export async function GET(_req: Request, props) {

--- a/app/about/opengraph-image/route.tsx
+++ b/app/about/opengraph-image/route.tsx
@@ -12,23 +12,18 @@ const rauchgPhoto = toArrayBuffer(
 );
 
 // Fonts
+const fontsDir = join(process.cwd(), "fonts");
+
 const inter300 = readFileSync(
-  join(
-    process.cwd(),
-    "node_modules/@fontsource/inter/files/inter-latin-300-normal.woff"
-  )
+  join(fontsDir, "inter-latin-300-normal.woff")
 );
+
 const inter500 = readFileSync(
-  join(
-    process.cwd(),
-    "node_modules/@fontsource/inter/files/inter-latin-500-normal.woff"
-  )
+  join(fontsDir, "inter-latin-500-normal.woff")
 );
+
 const robotoMono400 = readFileSync(
-  join(
-    process.cwd(),
-    "node_modules/@fontsource/roboto-mono/files/roboto-mono-latin-400-normal.woff"
-  )
+  join(fontsDir, "roboto-mono-latin-400-normal.woff")
 );
 
 export async function GET() {

--- a/app/about/page.mdx
+++ b/app/about/page.mdx
@@ -1,5 +1,15 @@
 import Image from "next/image";
 
+export const metadata = {
+  title: 'Guillermo Rauch',
+  description: 'An overview of my career and technical contributions',
+  openGraph: {
+    title: 'Vercel',
+    description: 'An overview of my career and technical contributions',
+    images: [{ url: '/about/opengraph-image' }]
+  }
+}
+
 # About
 
 <a href="https://twitter.com/rauchg" target="_blank">

--- a/app/opengraph-image/route.tsx
+++ b/app/opengraph-image/route.tsx
@@ -5,37 +5,18 @@ import { getPosts } from "@/app/get-posts";
 import { readFileSync } from "fs";
 import { join } from "path";
 
+const fontsDir = join(process.cwd(), "fonts");
+
 const inter300 = readFileSync(
-  join(
-    process.cwd(),
-    "node_modules",
-    "@fontsource",
-    "inter",
-    "files",
-    "inter-latin-300-normal.woff"
-  )
+  join(fontsDir, "inter-latin-300-normal.woff")
 );
 
 const inter600 = readFileSync(
-  join(
-    process.cwd(),
-    "node_modules",
-    "@fontsource",
-    "inter",
-    "files",
-    "inter-latin-600-normal.woff"
-  )
+  join(fontsDir, "inter-latin-600-normal.woff")
 );
 
 const robotoMono400 = readFileSync(
-  join(
-    process.cwd(),
-    "node_modules",
-    "@fontsource",
-    "roboto-mono",
-    "files",
-    "roboto-mono-latin-400-normal.woff"
-  )
+  join(fontsDir, "roboto-mono-latin-400-normal.woff")
 );
 
 export async function GET() {

--- a/fonts/init.mjs
+++ b/fonts/init.mjs
@@ -1,0 +1,35 @@
+// this script is run by the npm postinstall hook to copy the font
+// files from the node_modules directory to the public directory
+
+import fs from "fs";
+import path from "path";
+
+// Define the source paths
+const fontPaths = [
+  "node_modules/@fontsource/inter/files/inter-latin-300-normal.woff",
+  "node_modules/@fontsource/inter/files/inter-latin-500-normal.woff",
+  "node_modules/@fontsource/inter/files/inter-latin-600-normal.woff",
+  "node_modules/@fontsource/roboto-mono/files/roboto-mono-latin-400-normal.woff",
+];
+
+// Ensure the destination directory exists
+const ensureDirectoryExistence = filePath => {
+  const dirname = path.dirname(filePath);
+  if (fs.existsSync(dirname)) {
+    return true;
+  }
+  ensureDirectoryExistence(dirname);
+  fs.mkdirSync(dirname, { recursive: true });
+};
+
+// Copy each font file
+fontPaths.forEach(src => {
+  const fileName = path.basename(src);
+  const dest = path.join("fonts", fileName);
+  ensureDirectoryExistence(dest);
+  const exists = fs.existsSync(dest);
+  if (!exists) {
+    fs.copyFileSync(src, dest);
+    console.log(`Copied ${src} to ${dest}`);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "scripts": {
     "dev": "next dev --turbopack -H 0.0.0.0",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "postinstall": "node ./fonts/init.mjs"
   },
   "prettier": {
     "arrowParens": "avoid"


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR refactors font file handling by moving font files from the `node_modules` directory to a local `fonts` directory and updates the relevant imports across multiple files.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant NPM as NPM Install
    participant Init as Font Initializer
    participant App as Application Routes
    participant FS as File System

    NPM->>Init: Triggers postinstall script
    Init->>FS: Check if fonts directory exists
    Init->>FS: Create fonts directory if needed
    Init->>FS: Copy font files from node_modules
    Note over Init: Inter 300, 500, 600 & Roboto Mono 400

    App->>FS: Read font files from fonts directory
    Note over App: Multiple routes configure fonts:<br/>- /app/opengraph-image<br/>- /app/about/opengraph-image<br/>- /app/(post)/og/[id]
    
    App->>App: Configure metadata & OpenGraph
    Note over App: Set page metadata<br/>including OpenGraph images
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/rauchg/blog/pull/172/files#diff-2da5e66905a590c025b5c9d100ee761701f3d38a8ac734a20bb940a5c26c8f2b>app/(post)/og/[id]/route.tsx</a></td><td>Updated font file paths to use the new local fonts directory.</td></tr>
<tr><td><a href=https://github.com/rauchg/blog/pull/172/files#diff-cacb4d2a01902157f006945f795af415e0120de4e802582db19e7c037634d9d9>app/about/opengraph-image/route.tsx</a></td><td>Updated font file paths to use the new local fonts directory.</td></tr>
<tr><td><a href=https://github.com/rauchg/blog/pull/172/files#diff-38b6119fe9edab5739ee3c0b5d923e5b2969ea6ef6526408598b403e264ba788>app/about/page.mdx</a></td><td>Added metadata for the page.</td></tr>
<tr><td><a href=https://github.com/rauchg/blog/pull/172/files#diff-621ecc41519021856ed7267d95d30684655ba71ad51ec575c75237e7e05e2235>app/opengraph-image/route.tsx</a></td><td>Updated font file paths to use the new local fonts directory.</td></tr>
<tr><td><a href=https://github.com/rauchg/blog/pull/172/files#diff-4c07c84af74c646d782808d157744a5a1d4e17ace06620d7a1ab4541c48a9fc7>fonts/init.mjs</a></td><td>Added a script to copy font files from node_modules to the local fonts directory.</td></tr>
<tr><td><a href=https://github.com/rauchg/blog/pull/172/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519>package.json</a></td><td>Added a postinstall script to run the font copying script.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.mjs`, `.json`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


