### PR TITLE
fix: adapt to Notion API block record nesting change

### DIFF
--- a/app/(post)/2020/books-people-reread/books.tsx
+++ b/app/(post)/2020/books-people-reread/books.tsx
@@ -86,7 +86,7 @@ async function getData() {
         const blockData = col.recordMap.block[blockId];
 
         if (blockData) {
-          const props = blockData.value.properties;
+          const props = blockData.value.value.properties;
 
           if (!props) {
             // not sure when this happens yet, but it seems


### PR DESCRIPTION
The Notion internal API (`/api/v3/queryCollection`) changed its response structure — block records are now wrapped in an additional `{value, role}` object.

Properties moved from `block.value.properties` to `block.value.value.properties`, which caused the books grid on `/2020/books-people-reread` to render empty.